### PR TITLE
break typo causes testing problems

### DIFF
--- a/library/Rediska/KeyDistributor/ConsistentHashing.php
+++ b/library/Rediska/KeyDistributor/ConsistentHashing.php
@@ -143,7 +143,7 @@ class Rediska_KeyDistributor_ConsistentHashing implements Rediska_KeyDistributor
             if ($slice >= $this->_slicesCount) {
                 // If already looped once, something is wrong.
                 if ($looped) {
-                    break 2;
+                    break;
                 }
 
                 // Otherwise, loop back to the beginning.       


### PR DESCRIPTION
While integrating Rediska into our app and running unit tests on code that uses rediska, I noticed segfaults caused by this code when phpunit is being run to generate code coverage. See the xdebug bug for more info if you're interested.
