### PR TITLE
small fixes

### DIFF
--- a/library/Rediska/Autoloader.php
+++ b/library/Rediska/Autoloader.php
@@ -35,16 +35,29 @@ class Rediska_Autoloader
     /**
      * Register Rediska autoload
      *
+     * @param boolean $prepend Prepend the autoloader in the chain, the default is
+     *                         'false'. This parameter is available since PHP 5.3.0
+     *                         and will be silently disregarded otherwise.
      * @return boolean
      */
-    public static function register()
+    public static function register($prepend = false)
     {
         if (self::isRegistered()) {
             return false;
         }
+        if (!is_bool($prepend)) {
+            $prepend = (bool) $prepend;
+        }
 
-        self::$_isRegistered = spl_autoload_register(self::$_callback);
-
+        if (version_compare(PHP_VERSION, '5.3.0', '<')) {
+            self::$_isRegistered = spl_autoload_register(self::$_callback);
+        } else {
+            self::$_isRegistered = spl_autoload_register(
+                self::$_callback,
+                true,
+                $prepend
+            );
+        }
         return self::$_isRegistered;
     }
 
@@ -78,6 +91,8 @@ class Rediska_Autoloader
      * Load class
      *
      * @param string $className
+     *
+     * @return boolean
      */
     public static function load($className)
     {


### PR DESCRIPTION
- add parameter `$prepend`
  - used in autoloader registration
  - disregarded for < 5.3.0
- fixed phpdoc
