### PR TITLE
fix Serializer bug  - unserializing "numeric like" string

### DIFF
--- a/library/Rediska/Serializer.php
+++ b/library/Rediska/Serializer.php
@@ -99,7 +99,7 @@ class Rediska_Serializer
                 $unserializedValue = (float)$value;
             }
 
-            if ((string)$unserializedValue != $value) {
+            if ((string)$unserializedValue !== $value) {
                 $unserializedValue = $value;
             }
         } else {


### PR DESCRIPTION
fix bug of Serializer which drop zeros , when unserializing a "numeric like" string within zeros at the beginning

bug like this:
 "012345" unserialized as "12345"
