### PR TITLE
This patch enables auto_expire feature

### DIFF
--- a/library/Rediska.php
+++ b/library/Rediska.php
@@ -599,7 +599,7 @@ class Rediska extends Rediska_Options
 
         $expirableCommands = $this->getOption('expirableCommands');
         if(isset($expirableCommands[$name])){
-            if($name == 'expire'){
+            if(mb_strtolower($name) == 'expire'){
                 throw new Rediska_Exception('Expire cannot be expired');
             }
             $this->expire(array_shift($args), $expirableCommands[$name]);


### PR DESCRIPTION
This patch enables auto_expire feature. If passed an 'expirableCommands' option as a Command=>expireTimeInSeconds, there will be an auto_expire applied to all such commands. There is some unpredictable behavior if a command, which doesn't interact with single key is marked as expiarble. Just for now I have not got any idea to make it look better without global patches.
