### PR TITLE
Fix numerous test failures because PHPUnit 3.6 removed the assertType method

### DIFF
--- a/tests/library/Rediska/Command/ShiftFromListBlockingTest.php
+++ b/tests/library/Rediska/Command/ShiftFromListBlockingTest.php
@@ -32,7 +32,7 @@ class Rediska_Command_ShiftFromListBlockingTest extends Rediska_TestCase
         $this->rediska->appendToList('test', 'aaa');
 
         $reply = $this->rediska->shiftFromListBlocking(array('test', 'test2'));
-        $this->assertType('Rediska_Command_Response_ListNameAndValue', $reply);
+        $this->assertInstanceOf('Rediska_Command_Response_ListNameAndValue', $reply);
         $this->assertEquals('aaa', $reply->value);
         $this->assertEquals('test', $reply['name']);
 

--- a/tests/library/Rediska/Key/AbstractTest.php
+++ b/tests/library/Rediska/Key/AbstractTest.php
@@ -24,7 +24,7 @@ class Rediska_Key_AbstractTest extends Rediska_TestCase
 
     public function testGetRediska()
     {
-        $this->assertType('Rediska', $this->key->getRediska());
+        $this->assertInstanceOf('Rediska', $this->key->getRediska());
     }
 
     public function testSpecifiedServerAlias()

--- a/tests/library/Rediska/PipelineTest.php
+++ b/tests/library/Rediska/PipelineTest.php
@@ -5,10 +5,10 @@ class Rediska_PipelineTest extends Rediska_TestCase
     public function testPiplineInstance()
     {
         $instance = $this->rediska->pipeline();
-        $this->assertType('Rediska_Pipeline', $instance);
+        $this->assertInstanceOf('Rediska_Pipeline', $instance);
 
         $instance = $this->rediska->pipeline()->set('a', 'b');
-        $this->assertType('Rediska_Pipeline', $instance);
+        $this->assertInstanceOf('Rediska_Pipeline', $instance);
     }
 
     public function testPipelineIncapsulation()

--- a/tests/library/Rediska/Zend/QueueTest.php
+++ b/tests/library/Rediska/Zend/QueueTest.php
@@ -37,7 +37,7 @@ class Rediska_Zend_QueueTest extends Rediska_TestCase
     {
         $queue = $this->queue->createQueue('test');
         $reply = $queue->send(array(1, 2, 3));
-        $this->assertType($queue->getMessageClass(), $reply);
+        $this->assertInstanceOf($queue->getMessageClass(), $reply);
 
         $values = $this->rediska->getList('Zend_Queue_queue_test');
         $this->assertEquals(array(array(1, 2, 3)), $values);
@@ -56,7 +56,7 @@ class Rediska_Zend_QueueTest extends Rediska_TestCase
         $queue->send(array(1, 2, 3));
 
         $messages = $queue->receive();
-        $this->assertType($queue->getMessageSetClass(), $messages);
+        $this->assertInstanceOf($queue->getMessageSetClass(), $messages);
 
         $values = $messages->toArray();
         $this->assertEquals(array(1, 2, 3), $values[0]['body']);

--- a/tests/library/RediskaTest.php
+++ b/tests/library/RediskaTest.php
@@ -59,21 +59,21 @@ class RediskaTest extends Rediska_TestCase
     public function testTransaction()
     {
         $transaction = $this->rediska->transaction();
-        $this->assertType('Rediska_Transaction', $transaction);
+        $this->assertInstanceOf('Rediska_Transaction', $transaction);
     }
 
     public function testTransactionWithManyServersByAlias()
     {
         $this->_addSecondServerOrSkipTest();
         $transaction = $this->rediska->transaction('127.0.0.1:6380');
-        $this->assertType('Rediska_Transaction', $transaction);
+        $this->assertInstanceOf('Rediska_Transaction', $transaction);
     }
     
     public function testTransactionWithManyServersByOn()
     {
         $this->_addSecondServerOrSkipTest();
         $transaction = $this->rediska->on('127.0.0.1:6380')->transaction();
-        $this->assertType('Rediska_Transaction', $transaction);
+        $this->assertInstanceOf('Rediska_Transaction', $transaction);
     }
 
     public function testTransactionWithManyServersWithoutSpecifiedServer()


### PR DESCRIPTION
I add it to `Rediska_TestCase`.

This addresses some of the failures noticed in #54.
