### PR TITLE
Fix "Zend_Session_Exception: Session must be started before any output has been sent to the browser" errors in tests

### DIFF
--- a/tests/library/Rediska/Zend/AuthTest.php
+++ b/tests/library/Rediska/Zend/AuthTest.php
@@ -2,6 +2,8 @@
 
 require_once 'Zend/Auth.php';
 
+Zend_Session::$_unitTestEnabled = true;
+
 class Rediska_Zend_AuthTest extends Rediska_TestCase
 {
     /**


### PR DESCRIPTION
I added the following to `library/Rediska/Zend/AuthTest.php`:

``` php
Zend_Session::$_unitTestEnabled = true;
```

so that test don't fail with "Zend_Session_Exception: Session must be
started before any output has been sent to the browser".

Fixes 3 errors noticed in GH-54.
