### PR TITLE
Add a redis.conf that runs Redis on port 6380 for running the tests.

### DIFF
--- a/tests/redis.conf
+++ b/tests/redis.conf
@@ -1,0 +1,16 @@
+# By default Redis does not run as a daemon. Use 'yes' if you need it.
+# Note that Redis will write a pid file in /usr/local/var/run/redis.pid when daemonized.
+daemonize no
+
+# When running daemonized, Redis writes a pid file in /usr/local/var/run/redis.pid by
+# default. You can specify a custom pid file location here.
+pidfile /usr/local/var/run/redis.pid
+
+# Accept connections on the specified port, default is 6379.
+# If port 0 is specified Redis will not listen on a TCP socket.
+port 6380
+
+# If you want you can bind a single interface, if the bind option is not
+# specified all the interfaces will listen for incoming connections.
+#
+bind 127.0.0.1


### PR DESCRIPTION
This is useful for solving test failures noticed in GH-54.
