### PR TITLE
Rediska zend cache backend redis multi connection transactions

### DIFF
--- a/library/Rediska/Transaction.php
+++ b/library/Rediska/Transaction.php
@@ -11,6 +11,16 @@
  */
 class Rediska_Transaction
 {
+
+    /**
+     * @var string
+     */
+    const TRANSACTION_PREAMBLE = 'Transaction: ';
+
+    /**
+     * @var string
+     */
+    const TRANSACTION_EMPTY = 'Empty transaction';
     /**
      * Rediska instance
      * 
@@ -228,9 +238,9 @@ class Rediska_Transaction
     public function  __toString()
     {
         if (empty($this->_commands)) {
-            return 'Empty transaction';
+            return self::TRANSACTION_EMPTY;
         } else {
-            return 'Transaction: ' . implode(', ', $this->_commands);
+            return self::TRANSACTION_PREAMBLE . implode(', ', $this->_commands);
         }
     }
 


### PR DESCRIPTION
I moved the preamble for the `Rediska_Transaction::__toString` call for
both populated and empty transaction to a class constant. This was to
ensure uniformity of a potential future change not overlooking or
breaking the `Rediska_Zend_Cache_Backend_Redis` classes use in the
future. 

Two methods added that ensure transactions are executed on the
proper connection by key for multiple connection uses. When executing
the transaction if a transaction is empty `Rediska_Transaction::discard`
is called. This allows for more awareness of the
`Rediska_Transaction_AbortedException` and prevents it from being
erroneously thrown in execution is made with no commands being run.

This should also allow for effective use of `watch` and prevent inadvertent
catching of _real_ exceptions in the execution flow.
