### PR TITLE
Fixed unit tests for multi server `INFO` command

### DIFF
--- a/tests/library/Rediska/Command/InfoTest.php
+++ b/tests/library/Rediska/Command/InfoTest.php
@@ -16,10 +16,10 @@ class Rediska_Command_InfoTest extends Rediska_TestCase
         $this->_addSecondServerOrSkipTest();
 
         $info = $this->rediska->info();
-        $this->assertInstanceOf('Rediska_Info', $info);
 
         foreach($this->rediska->getConnections() as $connection) {
             $this->assertArrayHasKey($connection->getAlias(), $info);
+            $this->assertInstanceOf('Rediska_Info', $info[$connection->getAlias()]);
             $this->assertNotNull($info[$connection->getAlias()]->redis_version);
         }
     }

--- a/tests/library/Rediska/Command/SlaveOfTest.php
+++ b/tests/library/Rediska/Command/SlaveOfTest.php
@@ -43,6 +43,6 @@ class Rediska_Command_SlaveOfTest extends Rediska_TestCase
     protected function _checkRole($server, $role)
     {
         $info = $this->rediska->on($server->getAlias())->info();
-        $this->assertEquals($role, $info['role']);
+        $this->assertEquals($role, $info->role);
     }
 }


### PR DESCRIPTION
Unit tests were erroneously built for multiple connections and not
properly asserting upon actual results. `SlaveOfTest.php` was expecting
an array not an object. Multi-Connection tests in `InfoTest` was not
using array result sets.
