### PR TITLE
Proposal to change composer to use psr-0 path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,8 @@
         "zendframework/zendframework": "1.11.*"
     },
     "autoload": {
-        "classmap": ["library"]
+        "psr-0":{
+            "Rediska":["library/", "tests/library/"]
+        }
     }
 }


### PR DESCRIPTION
This changes would make Rediska a psr-0 autoloading package in a
composer environment. Giving the user the option using `php
composer.phar dump-autoload --optimize` for a classmap if desired.

We have experienced issues with the classmap primarily due to a legacy
autoloader that has not be refactored out. We currently maintain this library
as a fork with this change in it and keeping it mirrored otherwise. 

I am seeking feedback if there are objections to this or otherwise, it should
present any BC issues as the auto-include is rebuilt with each issuance
of the composer commands.
