### PR TITLE
Refactoring: move connection classes to constants

### DIFF
--- a/library/Rediska.php
+++ b/library/Rediska.php
@@ -36,6 +36,18 @@ class Rediska extends Rediska_Options
      * @var string
      */
     const DEFAULT_NAME = 'default';
+    
+    /**
+     * Default connection class
+     * @var string
+     */
+    const CONNECTION_CLASS = 'Rediska_Connection';
+    
+    /**
+     * Default socket connection class
+     * @var string
+     */
+    const CONNECTION_SOCKET_CLASS = 'Rediska_Connection_Socket';
 
     /**
      * Connections
@@ -238,11 +250,11 @@ class Rediska extends Rediska_Options
 
         if (isset($options['useSocket'])) {
             if ($options['useSocket'] == true) {
-                $connectionClass = 'Rediska_Connection_Socket';
+                $connectionClass = static::CONNECTION_SOCKET_CLASS;
             }
             unset($options['useSocket']);
         } else {
-            $connectionClass = 'Rediska_Connection';
+            $connectionClass = static::CONNECTION_CLASS;
         }
 
         $this->_connections[$connectionString] = new $connectionClass($options);


### PR DESCRIPTION
Избавление от жестко захардкоженных имен классов connections, что позволит их переопределять без перегрузки всего метода Rediska::addServer