### PR TITLE
Fix in Zend Session for work with PHP >= 7.1

### DIFF
--- a/library/Rediska/Zend/Session/SaveHandler/Redis.php
+++ b/library/Rediska/Zend/Session/SaveHandler/Redis.php
@@ -120,7 +120,7 @@ class Rediska_Zend_Session_SaveHandler_Redis extends Rediska_Options_RediskaInst
      */
     public function read($id)
     {
-        return $this->getRediska()->get($this->_getKeyName($id));
+        return (string) $this->getRediska()->get($this->_getKeyName($id));
     }
 
     /**


### PR DESCRIPTION
The session must return an string, with `(string)` casting this function returns an empty string instead of null. More information in: http://php.net/manual/en/function.session-start.php#120589.